### PR TITLE
chore: update dependencies in Scarb.lock and Scarb.toml to version 0.…

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "snforge_scarb_plugin"
+version = "0.33.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.33.0#221b1dbff42d650e9855afd4283508da8f8cacba"
+
+[[package]]
 name = "snforge_std"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.13.1#e1412ed040d10e66be0fd84115f72a667b57a116"
+version = "0.33.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.33.0#221b1dbff42d650e9855afd4283508da8f8cacba"
+dependencies = [
+ "snforge_scarb_plugin",
+]

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -6,8 +6,8 @@ edition = "2023_10"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.13.1" }
-starknet = "2.4.1"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.33.0" }
+starknet = "2.8.0"
 
 [[target.starknet-contract]]
 casm = true


### PR DESCRIPTION

This pull request updates the dependencies in the `Scarb.toml` file for the `contracts` project to ensure compatibility and leverage new features and fixes. The most important changes include upgrading the `snforge_std` and `starknet` dependencies.

Dependency updates:

* [`contracts/Scarb.toml`](diffhunk://#diff-7e80d69045b8e5b24be88ccea639af6143ffece769a45745bd535e82b309f9edL9-R10): Updated `snforge_std` dependency to tag `v0.33.0` from `v0.13.1` to ensure compatibility with the latest version of the library.
* [`contracts/Scarb.toml`](diffhunk://#diff-7e80d69045b8e5b24be88ccea639af6143ffece769a45745bd535e82b309f9edL9-R10): Updated `starknet` dependency to version `2.8.0` from `2.4.1` to include the latest features and fixes.