### PR TITLE
chore: update Starknet dependency to version 2.8.2 and refactor stora…

### DIFF
--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -7,7 +7,7 @@ edition = "2023_10"
 
 [dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.33.0" }
-starknet = "2.8.0"
+starknet = "2.8.2"
 
 [[target.starknet-contract]]
 casm = true

--- a/contracts/src/strapex_factory.cairo
+++ b/contracts/src/strapex_factory.cairo
@@ -26,6 +26,7 @@ mod strapex_factory {
     use core::starknet::event::EventEmitter;
     use contract_strapex::ownership_component::IOwnable;
     use contract_strapex::ownership_component::ownable_component;
+    use starknet::storage::Map;
     component!(path: ownable_component, storage: ownable, event: OwnableEvent);
 
     #[abi(embed_v0)]
@@ -35,7 +36,7 @@ mod strapex_factory {
     #[storage]
     struct Storage {
         strapexChildHash: ClassHash,
-        strapexChildOwner: LegacyMap<ContractAddress, ContractAddress>,
+        strapexChildOwner: Map<ContractAddress, ContractAddress>,
         totalStrapexAccountsNo: u128,
         depositToken: ContractAddress,
         #[substorage(v0)]


### PR DESCRIPTION
This pull request includes several updates to the `strapex_contract` and `strapex_factory` modules in the `contracts` directory. The changes primarily focus on updating dependencies, modifying storage structures, and improving ownership handling.

### Dependency Updates:
* Updated the `starknet` dependency in `contracts/Scarb.toml` from version `2.8.0` to `2.8.2`.

### Storage Structure Modifications:
* Replaced `LegacyMap` with `Map` for the `payments` field in `strapex_contract` and `strapexChildOwner` field in `strapex_factory`. [[1]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L61-R62) [[2]](diffhunk://#diff-498b0c5965af3e43b95954c191159c98ff4faa76afdbc6f44c4ce5f68658e651L38-R39)

### Ownership Handling Improvements:
* Removed the `owner` field and replaced its usage with `ownable.owner()` in multiple functions within `strapex_contract`. This change ensures that ownership checks are done through the `ownable_component`. [[1]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L125-R126) [[2]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L173-R174) [[3]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L203-R204) [[4]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L237-R238) [[5]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L265-R266) [[6]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L281-R282) [[7]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729L301-R302)

### Code Clean-up:
* Removed the commented-out `owner` field from the `Storage` struct in `strapex_contract`.

### Additional Imports:
* Added the `starknet::storage::Map` import in both `strapex_contract` and `strapex_factory` modules. [[1]](diffhunk://#diff-71ee5fab0bbb8ef0d736308ff807b6b1fb0cc1b449404835922ef56373e11729R42) [[2]](diffhunk://#diff-498b0c5965af3e43b95954c191159c98ff4faa76afdbc6f44c4ce5f68658e651R29)…ge types in strapex_contract and strapex_factory to use Map